### PR TITLE
Allow (un)packing structs containing Vec<T> with #[derive(MsgPacker)]

### DIFF
--- a/msgpacker/src/binary.rs
+++ b/msgpacker/src/binary.rs
@@ -1,0 +1,38 @@
+use core::ops::Deref;
+
+/// Wrapper struct to mark [u8] that are packed as bin rather than array
+#[derive(Debug, PartialEq)]
+pub struct MsgPackerBinSlice<'a>(pub &'a [u8]);
+
+impl<'a> Deref for MsgPackerBinSlice<'a> {
+    type Target = [u8];
+
+    fn deref(&self) -> &'a Self::Target {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub mod alloc {
+    use super::*;
+    use ::alloc::vec::Vec;
+
+    /// Wrapper struct to mark Vec<u8> that are packed as bin rather than array
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct MsgPackerBin(pub Vec<u8>);
+
+    impl MsgPackerBin {
+        /// Extracts a MsgPackerBinSlice containing the entire MsgPackerBin.
+        pub fn as_slice(&self) -> MsgPackerBinSlice {
+            MsgPackerBinSlice(self.0.as_slice())
+        }
+    }
+
+    impl Deref for MsgPackerBin {
+        type Target = Vec<u8>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+}

--- a/msgpacker/src/lib.rs
+++ b/msgpacker/src/lib.rs
@@ -13,6 +13,7 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 mod extension;
 
+mod binary;
 mod error;
 mod format;
 mod helpers;
@@ -91,6 +92,10 @@ pub trait Unpackable: Sized {
 /// Required types for the library.
 pub mod prelude {
     pub use super::{Error, Packable, Unpackable};
+
+    #[cfg(feature = "alloc")]
+    pub use super::binary::alloc::MsgPackerBin;
+    pub use super::binary::MsgPackerBinSlice;
 
     #[cfg(feature = "derive")]
     pub use super::MsgPacker;

--- a/msgpacker/src/pack/binary.rs
+++ b/msgpacker/src/pack/binary.rs
@@ -1,7 +1,8 @@
 use super::{Format, Packable};
+use crate::binary::MsgPackerBinSlice;
 use core::iter;
 
-impl Packable for [u8] {
+impl<'a> Packable for MsgPackerBinSlice<'a> {
     #[allow(unreachable_code)]
     fn pack<T>(&self, buf: &mut T) -> usize
     where
@@ -57,9 +58,10 @@ impl Packable for str {
 #[cfg(feature = "alloc")]
 mod alloc {
     use super::*;
-    use ::alloc::{string::String, vec::Vec};
+    use crate::binary::alloc::MsgPackerBin;
+    use ::alloc::string::String;
 
-    impl Packable for Vec<u8> {
+    impl Packable for MsgPackerBin {
         fn pack<T>(&self, buf: &mut T) -> usize
         where
             T: Extend<u8>,

--- a/msgpacker/src/pack/collections.rs
+++ b/msgpacker/src/pack/collections.rs
@@ -68,6 +68,19 @@ where
 mod alloc {
     use super::*;
     use ::alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+    use ::alloc::vec::Vec;
+
+    impl<X> Packable for Vec<X>
+    where
+        X: Packable,
+    {
+        fn pack<T>(&self, buf: &mut T) -> usize
+        where
+            T: Extend<u8>,
+        {
+            pack_array(buf, self)
+        }
+    }
 
     impl<X> Packable for BTreeSet<X>
     where

--- a/msgpacker/src/unpack/binary.rs
+++ b/msgpacker/src/unpack/binary.rs
@@ -37,14 +37,15 @@ pub fn unpack_str(mut buf: &[u8]) -> Result<(usize, &str), Error> {
 #[cfg(feature = "alloc")]
 mod alloc {
     use super::*;
+    use crate::binary::alloc::MsgPackerBin;
     use crate::helpers::{take_byte_iter, take_num_iter};
     use ::alloc::{string::String, vec::Vec};
 
-    impl Unpackable for Vec<u8> {
+    impl Unpackable for MsgPackerBin {
         type Error = Error;
 
         fn unpack(buf: &[u8]) -> Result<(usize, Self), Self::Error> {
-            unpack_bytes(buf).map(|(n, b)| (n, b.to_vec()))
+            unpack_bytes(buf).map(|(n, b)| (n, MsgPackerBin(b.to_vec())))
         }
 
         fn unpack_iter<I>(bytes: I) -> Result<(usize, Self), Self::Error>
@@ -69,7 +70,7 @@ mod alloc {
             if v.len() < len {
                 return Err(Error::BufferTooShort);
             }
-            Ok((n + len, v))
+            Ok((n + len, MsgPackerBin(v)))
         }
     }
 

--- a/msgpacker/src/unpack/collections.rs
+++ b/msgpacker/src/unpack/collections.rs
@@ -138,6 +138,25 @@ where
 mod alloc {
     use super::*;
     use ::alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+    use ::alloc::vec::Vec;
+
+    impl<X> Unpackable for Vec<X>
+    where
+        X: Unpackable + Ord,
+    {
+        type Error = <X as Unpackable>::Error;
+
+        fn unpack(buf: &[u8]) -> Result<(usize, Self), Self::Error> {
+            unpack_array(buf)
+        }
+
+        fn unpack_iter<I>(bytes: I) -> Result<(usize, Self), Self::Error>
+        where
+            I: IntoIterator<Item = u8>,
+        {
+            unpack_array_iter(bytes)
+        }
+    }
 
     impl<X> Unpackable for BTreeSet<X>
     where

--- a/msgpacker/tests/binary.rs
+++ b/msgpacker/tests/binary.rs
@@ -5,11 +5,11 @@ mod utils;
 
 #[test]
 fn empty_vec() {
-    let v = vec![];
+    let v = MsgPackerBin(vec![]);
     let mut bytes = vec![];
     let n = v.pack(&mut bytes);
-    let (o, x) = Vec::<u8>::unpack(&bytes).unwrap();
-    let (p, y) = Vec::<u8>::unpack_iter(bytes).unwrap();
+    let (o, x) = MsgPackerBin::unpack(&bytes).unwrap();
+    let (p, y) = MsgPackerBin::unpack_iter(bytes).unwrap();
     assert_eq!(o, n);
     assert_eq!(p, n);
     assert_eq!(v, x);
@@ -31,19 +31,8 @@ fn empty_str() {
 
 proptest! {
     #[test]
-    fn vec(v: Vec<u8>) {
-        utils::case(v);
-    }
-
-    #[test]
     fn str(s: String) {
         utils::case(s);
-    }
-
-    #[test]
-    #[ignore]
-    fn large_vec(v in prop::collection::vec(any::<u8>(), 0..=u16::MAX as usize * 2)) {
-        utils::case(v);
     }
 
     #[test]

--- a/msgpacker/tests/collections.rs
+++ b/msgpacker/tests/collections.rs
@@ -32,7 +32,9 @@ struct Value {
     pub t11: PhantomData<String>,
     pub t12: Option<bool>,
     pub t13: Option<Vec<u8>>,
-    pub t14: Option<String>,
+    pub t14: Option<Vec<u16>>,
+    pub t15: Option<Vec<u32>>,
+    pub t16: Option<String>,
 }
 
 proptest! {


### PR DESCRIPTION
Currently the following code doesn't work:
```rust
#[derive(MsgPacker)]
pub struct A {
    b: Vec<u32>,
}
```
because `Vec<T>` doesn't implement `Packable`.

This PR changes the binary (un)packer to apply to a new `MsgPackerBin` wrapper type used to mark `Vec<u8>` that should be encoded as msgpack binary format.

This free the way to implement (Un)Packable for `Vec<T>` and thus allows `Vec<T>` to be packed as msgpack array format, fixing the above mentioned code.